### PR TITLE
IDEA-246311 Show branch coverage

### DIFF
--- a/report-builder/resources/htmlTemplates/macros.ftl
+++ b/report-builder/resources/htmlTemplates/macros.ftl
@@ -2,7 +2,7 @@
 
 <#macro currentScope>Current scope: </#macro>
 
-<#macro coverageStatCell statEntry>
+<#macro coverageStatCell statEntry showEmpty=false>
 <#if statEntry.percent &gt;= 0>
 <td class="coverageStat">
   <span class="percent">
@@ -16,6 +16,10 @@
            >)
   </span>
 </td>
+<#else>
+  <#if showEmpty>
+    <td class="coverageStat"/>
+  </#if>
 </#if>
 </#macro>
 
@@ -42,12 +46,12 @@
 
 <#macro sortableCellLabel label sortOption><a href="${paths.getOrder(sortOption)}">${label}</a></#macro>
 
-<#macro coverageStatRow coverageStatistics showForClass=true>
+<#macro coverageStatRow coverageStatistics showForClass=true showEmptyBlocks=false>
 <#if showForClass>
 <@coverageStatCell statEntry=coverageStatistics.classStats/>
 </#if>
 <@coverageStatCell statEntry=coverageStatistics.methodStats/>
-<@coverageStatCell statEntry=coverageStatistics.blockStats/>
+<@coverageStatCell statEntry=coverageStatistics.blockStats showEmpty=showEmptyBlocks/>
 <@coverageStatCell statEntry=coverageStatistics.lineStats/>
 <@coverageStatCell statEntry=coverageStatistics.statementStats/>
 </#macro>

--- a/report-builder/resources/htmlTemplates/modules.ftl
+++ b/report-builder/resources/htmlTemplates/modules.ftl
@@ -16,18 +16,17 @@
 <h2>Coverage Breakdown</h2>
 
 <table class="coverageStats">
+<#assign showBlocks=statsCalculator.overallStats.blockStats.percent &gt;= 0>
+<tr>
+  <th class="name  <@sortableCellClass sorted=sortOption.orderByName() sortedDesc=sortOption.descendingOrder/>">
+    <@sortableCellLabel label=resources['coverage.module']?cap_first sortOption=sortOption.nextOrderByName()/>
+  </th>
+  <@coverageStatHeaderRow coverageStatistics=statsCalculator.overallStats sortOption=sortOption/>
+</tr>
 <#list modules as ms>
-  <#if ms == modules?first>
-  <tr>
-    <th class="name  <@sortableCellClass sorted=sortOption.orderByName() sortedDesc=sortOption.descendingOrder/>">
-      <@sortableCellLabel label=resources['coverage.module']?cap_first sortOption=sortOption.nextOrderByName()/>
-    </th>
-    <@coverageStatHeaderRow coverageStatistics=statsCalculator.getForModule(ms.name) sortOption=sortOption/>
-  </tr>
-  </#if>
   <tr>
     <td class="name"><a href="${paths.getNamespacesIndexPath(ms, sortOption)}"><@moduleName module=ms/></a></td>
-    <@coverageStatRow coverageStatistics=statsCalculator.getForModule(ms.name)/>
+    <@coverageStatRow coverageStatistics=statsCalculator.getForModule(ms.name) showEmptyBlocks=showBlocks/>
   </tr>
 </#list>
 </table>

--- a/report-builder/resources/htmlTemplates/namespaceIndex.ftl
+++ b/report-builder/resources/htmlTemplates/namespaceIndex.ftl
@@ -29,20 +29,19 @@
 <br/>
 
 <table class="coverageStats">
+<#assign sortDesc=sortOption.descendingOrder>
+<#assign sortByName=sortOption.orderByName()>
+<#assign showBlocks=statsCalculator.getForNamespace(module.name, namespace).blockStats.percent &gt;= 0>
+<tr>
+  <th class="name  <@sortableCellClass sorted=sortByName sortedDesc=sortDesc/>">
+    <@sortableCellLabel label=resources['coverage.class']?cap_first sortOption=sortOption.nextOrderByName()/>
+  </th>
+    <@coverageStatHeaderRow coverageStatistics=statsCalculator.getForNamespace(module.name, namespace) sortOption=sortOption/>
+</tr>
 <#list classes as class>
-  <#if class == classes?first>
-  <#assign sortDesc=sortOption.descendingOrder>
-  <#assign sortByName=sortOption.orderByName()>
-  <tr>
-    <th class="name  <@sortableCellClass sorted=sortByName sortedDesc=sortDesc/>">
-      <@sortableCellLabel label=resources['coverage.class']?cap_first sortOption=sortOption.nextOrderByName()/>
-    </th>
-    <@coverageStatHeaderRow coverageStatistics=statsCalculator.getForClassWithInnerClasses(class) sortOption=sortOption/>
-  </tr>
-  </#if>
   <tr>
     <td class="name"><a href="${paths.getClassCoveragePath(module, namespace, class)}"><@className clazz=class/></a></td>
-    <@coverageStatRow coverageStatistics=statsCalculator.getForClassWithInnerClasses(class)/>
+    <@coverageStatRow coverageStatistics=statsCalculator.getForClassWithInnerClasses(class) showEmptyBlocks=showBlocks/>
   </tr>
 </#list>
 </table>

--- a/report-builder/resources/htmlTemplates/namespaces.ftl
+++ b/report-builder/resources/htmlTemplates/namespaces.ftl
@@ -26,20 +26,19 @@
 <h2>Coverage Breakdown</h2>
 
 <table class="coverageStats">
+<#assign sortDesc=sortOption.descendingOrder>
+<#assign sortByName=sortOption.orderByName()>
+<#assign showBlocks=statsCalculator.getForModule(module.name).blockStats.percent &gt;= 0>
+<tr>
+  <th class="name  <@sortableCellClass sorted=sortByName sortedDesc=sortDesc/>">
+    <@sortableCellLabel label=resources['coverage.namespace']?cap_first sortOption=sortOption.nextOrderByName()/>
+  </th>
+  <@coverageStatHeaderRow coverageStatistics=statsCalculator.getForModule(module.name) sortOption=sortOption/>
+</tr>
 <#list namespaces as ns>
-  <#if ns == namespaces?first>
-  <#assign sortDesc=sortOption.descendingOrder>
-  <#assign sortByName=sortOption.orderByName()>
-  <tr>
-    <th class="name  <@sortableCellClass sorted=sortByName sortedDesc=sortDesc/>">
-      <@sortableCellLabel label=resources['coverage.namespace']?cap_first sortOption=sortOption.nextOrderByName()/>
-    </th>
-    <@coverageStatHeaderRow coverageStatistics=statsCalculator.getForNamespace(module.name, ns) sortOption=sortOption/>
-  </tr>
-  </#if>
   <tr>
     <td class="name"><a href="${paths.getClassesIndexPath(module, ns, sortOption)}"><@namespaceName namespace=ns/></a></td>
-    <@coverageStatRow coverageStatistics=statsCalculator.getForNamespace(module.name, ns)/>
+    <@coverageStatRow coverageStatistics=statsCalculator.getForNamespace(module.name, ns) showEmptyBlocks=showBlocks/>
   </tr>
 </#list>
 </table>

--- a/report-builder/src/jetbrains/coverage/report/idea/IDEACoverageClassInfo.java
+++ b/report-builder/src/jetbrains/coverage/report/idea/IDEACoverageClassInfo.java
@@ -16,6 +16,7 @@
 
 package jetbrains.coverage.report.idea;
 
+import com.intellij.rt.coverage.data.BranchData;
 import com.intellij.rt.coverage.data.ClassData;
 import com.intellij.rt.coverage.data.LineCoverage;
 import com.intellij.rt.coverage.data.LineData;
@@ -91,7 +92,20 @@ public class IDEACoverageClassInfo extends JavaClassInfo {
   }
 
   public Entry getBlockStats() {
-    return null;
+    int total = 0;
+    int covered = 0;
+    if (myClassData == null) return null;
+    Object[] lines = myClassData.getLines();
+    if (lines == null) return null;
+    for (Object l: lines) {
+      if (l == null) continue;
+      LineData line = (LineData) l;
+      BranchData branches = line.getBranchData();
+      if (branches == null) continue;
+      total += branches.getTotalBranches();
+      covered += branches.getCoveredBranches();
+    }
+    return new Entry(total, covered);
   }
 
   public Entry getStatementStats() {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-246311

1) Show block statistics in coverage report.
2) Header cells are determined by module(or namespace) but not by the first row in order to show block stats in case when the first line does not have any blocks. In case when at least one class in module has block stats, all classes in the module shouldn't skip block cell.